### PR TITLE
Vagrant Machine - Apache2 error on vagrant provisioning fix

### DIFF
--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -13,6 +13,19 @@
     - expires
     - filter
 
+#
+# Preventing "Apache is running a threaded MPM, but your PHP Module..."
+# http://stackoverflow.com/questions/19185268/php-and-apache-thread-safe-error
+- name: Disabling mpm_event module
+  sudo: yes
+  command: a2dismod mpm_event
+
+- name: Enabling mpm_prefork module
+  sudo: yes
+  command: a2enmod mpm_prefork
+  notify: restart apache
+#
+
 - shell: apache2 -v
   register: apache_version
 


### PR DESCRIPTION
fixing issue with apache2 running threaded MPM, but PHP being compiled threadsafe
